### PR TITLE
ap: obviate need for "len" variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,10 @@
 
 const ZipArray = xs => ({
   map: f => ZipArray(xs.map(x => f(x))),
-  ap: ys => {
-    const zs = ys.runZipArray;
-    let result = [];
-
-    for (let i = 0, len = Math.min(xs.length, zs.length); i < len; ++i) {
-      result.push(xs[i](zs[i]));
-    }
-
+  ap: zipArray => {
+    const ys = zipArray.runZipArray;
+    const result = new Array(Math.min(xs.length, ys.length));
+    for (let i = 0; i < result.length; ++i) result[i] = xs[i](ys[i]);
     return ZipArray(result);
   },
   runZipArray: xs,


### PR DESCRIPTION
It seems a bit cleaner to me to preallocate the array slots. You're welcome to merge if you agree. :)
